### PR TITLE
Add non-optimized flag to 'react-scripts build'

### DIFF
--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -16,11 +16,13 @@ Current upstream with `react-scripts@3.4.1`.
 
   > Note: These configuration variables are an extension of the [Advanced Configurations](create-react-app.dev/docs/advanced-configuration) supported by create-react-app.
 
-  | Variable                | Development | Production | Usage                                                                                                                                                                    |
-  | ----------------------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-  | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the fast-sass-loader instead of sass-loader. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files. |
-  | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                  |
-  | USE_FULL_SOURCEMAP | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds.|
+  | Variable                | Development | Production | Usage                                                                                                                                                                                                |
+  | ----------------------- | ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the fast-sass-loader instead of sass-loader. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files.         |
+  | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                          |
+  | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
+  | NON_OPTIMIZED           | 🚫 Ignored  | ✅ Used    | When set to `true`,                                                                                                                                                                                  |
+
 - Typing changes
 
   - By default, typescript tests are not type checked causing issue when trying to compile them later.

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -59,6 +59,8 @@ const shouldDebugBuildPerformance =
 
 const shouldUseProdSourceMap = process.env.USE_FULL_SOURCEMAP === 'true';
 
+const shouldNotOptimize = process.env.NON_OPTIMIZED === 'true';
+
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -175,7 +177,7 @@ module.exports = function(webpackEnv) {
           inject: true,
           template: paths.appHtml,
         },
-        isEnvProduction
+        isEnvProduction && !shouldNotOptimize
           ? {
               minify: {
                 removeComments: true,
@@ -291,7 +293,7 @@ module.exports = function(webpackEnv) {
       globalObject: 'this',
     },
     optimization: {
-      minimize: isEnvProduction,
+      minimize: isEnvProduction && !shouldNotOptimize,
       minimizer: [
         // This is only used in production mode
         new TerserPlugin({
@@ -538,7 +540,7 @@ module.exports = function(webpackEnv) {
                 cacheDirectory: true,
                 // See #6846 for context on why cacheCompression is disabled
                 cacheCompression: false,
-                compact: isEnvProduction,
+                compact: isEnvProduction && !shouldNotOptimize,
               },
             },
             // Process any JS outside of the app with Babel.


### PR DESCRIPTION
Some workflows cannot easily take advantage of dev server in 'react-scripts start', such as a mobile application, so we need to have an option to get a faster local build written to disk.