### PR TITLE
Update main README

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -1,6 +1,8 @@
-# react-scripts
+# @bentley/react-scripts
 
-This package includes scripts and configuration used by [Create React App](https://github.com/facebook/create-react-app).<br>
+This is the iModel.js fork of react-scripts. Visit our [README](https://github.com/imodeljs/create-react-app/blob/imodeljs/packages/react-scripts/README-imodeljs.md) for information about the fork and the reason behind it.
+
+This package includes scripts and configuration used by [Create React App](https://github.com/imodeljs/create-react-app).<br>
 Please refer to its documentation:
 
 - [Getting Started](https://facebook.github.io/create-react-app/docs/getting-started) – How to create a new app.


### PR DESCRIPTION
While reviewing the README on [npmjs](https://www.npmjs.com/package/@bentley/react-scripts), it lacks any helpful information about why we have our own version of react-scripts.  I updated it to at least point to the README-imodeljs.

This will cause additional conflicts with upstream but the one line shouldn't be too hard to manage :)