### PR TITLE
Bump resolve-url-loader version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "react-app-polyfill": "^1.0.6",
     "react-dev-utils": "^10.2.1",
     "resolve": "1.15.0",
-    "resolve-url-loader": "3.1.1",
+    "resolve-url-loader": "3.1.2",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
     "source-map-loader": "^1.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump resolve-url-loader to pull in new version of adjust-sourcemap-loader that removes the object-path dependency.  The object-path dependency had a high severity audit error, https://www.npmjs.com/advisories/1573. 