### PR TITLE
Update to latest react-dev-utils package

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -71,7 +71,7 @@
     "postcss-preset-env": "6.7.0",
     "postcss-safe-parser": "4.0.1",
     "react-app-polyfill": "^1.0.6",
-    "react-dev-utils": "^10.2.1",
+    "react-dev-utils": "^11.0.3",
     "resolve": "1.15.0",
     "resolve-url-loader": "3.1.2",
     "sass-loader": "8.0.2",


### PR DESCRIPTION
This updates to the latest version of react-dev-utils.  I still need to test this out with CRA 3 as upstream only made the fix to CRA 4.x.  Not sure what breaking changes may exist...  I'd really like to avoid us forking react-dev-utils though.