### PR TITLE
Update to fast-sass-loader v2

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "^1.6.1",
-    "fast-sass-loader": "^1.5.0",
+    "fast-sass-loader": "^2.0.0",
     "file-loader": "4.3.0",
     "fs-extra": "^8.1.0",
     "html-webpack-plugin": "4.0.0-beta.11",


### PR DESCRIPTION
Update to version 2.0.0 of fast-sass-loader.

Version 2 introduces support for dart-sass, which means it may finally be an option for us again. I did some initial testing and it looks like switching back to fast-sass-loader (w/ dart-sass) should speedup ui-test-app builds by more than 2x.
