### PR TITLE
Add options to improve build performance

### DIFF
--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -23,6 +23,7 @@ Current upstream with `react-scripts@3.4.1`.
   | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
   | DISABLE_ESLINT          | ✅ Used     | ✅ Used    | When set to `true`, webpack will not run eslint at all. This can speedup builds when you want to keep build and lint as separate steps. |
   | TRANSPILE_DEPS          | ✅ Used     | ✅ Used    | When set to `false`, webpack will not run babel on anything in node_modules. Transpiling dependencies can be costly, and is often not necessary when targeting newer browsers. |
+  | DISABLE_TERSER          | 🚫 Ignored  | ✅ Used    | When set to `true`, skips all minification. Useful for PR builds and test apps. |
 
 - Typing changes
 

--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -22,6 +22,7 @@ Current upstream with `react-scripts@3.4.1`.
   | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                          |
   | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
   | DISABLE_ESLINT          | ✅ Used     | ✅ Used    | When set to `true`, webpack will not run eslint at all. This can speedup builds when you want to keep build and lint as separate steps. |
+  | TRANSPILE_DEPS          | ✅ Used     | ✅ Used    | When set to `false`, webpack will not run babel on anything in node_modules. Transpiling dependencies can be costly, and is often not necessary when targeting newer browsers. |
 
 - Typing changes
 

--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -21,6 +21,7 @@ Current upstream with `react-scripts@3.4.1`.
   | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the fast-sass-loader instead of sass-loader. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files.         |
   | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                          |
   | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
+  | DISABLE_ESLINT          | ✅ Used     | ✅ Used    | When set to `true`, webpack will not run eslint at all. This can speedup builds when you want to keep build and lint as separate steps. |
 
 - Typing changes
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -61,6 +61,9 @@ const shouldDebugBuildPerformance =
 const shouldUseProdSourceMap = process.env.USE_FULL_SOURCEMAP === 'true';
 
 const shouldLint = process.env.DISABLE_ESLINT !== 'true';
+
+const shouldTranspileDeps = process.env.TRANSPILE_DEPS !== 'false';
+
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -547,7 +550,7 @@ module.exports = function(webpackEnv) {
             },
             // Process any JS outside of the app with Babel.
             // Unlike the application JS, we only compile the standard ES features.
-            {
+            shouldTranspileDeps && {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
               loader: require.resolve('babel-loader'),
@@ -681,7 +684,7 @@ module.exports = function(webpackEnv) {
             },
             // ** STOP ** Are you adding a new loader?
             // Make sure to add the new loader(s) before the "file" loader.
-          ],
+          ].filter(Boolean),
         },
       ].filter(Boolean),
     },

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -64,6 +64,8 @@ const shouldLint = process.env.DISABLE_ESLINT !== 'true';
 
 const shouldTranspileDeps = process.env.TRANSPILE_DEPS !== 'false';
 
+const shouldMinify = process.env.DISABLE_TERSER !== 'true';
+
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -296,7 +298,7 @@ module.exports = function(webpackEnv) {
       globalObject: 'this',
     },
     optimization: {
-      minimize: isEnvProduction,
+      minimize: isEnvProduction && shouldMinify,
       minimizer: [
         // This is only used in production mode
         new TerserPlugin({

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -60,6 +60,7 @@ const shouldDebugBuildPerformance =
 
 const shouldUseProdSourceMap = process.env.USE_FULL_SOURCEMAP === 'true';
 
+const shouldLint = process.env.DISABLE_ESLINT !== 'true';
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -433,7 +434,7 @@ module.exports = function(webpackEnv) {
 
         // First, run the linter.
         // It's important to do this before Babel processes the JS.
-        {
+        shouldLint && {
           test: /\.(js|mjs|jsx|ts|tsx)$/,
           enforce: 'pre',
           use: [
@@ -682,7 +683,7 @@ module.exports = function(webpackEnv) {
             // Make sure to add the new loader(s) before the "file" loader.
           ],
         },
-      ],
+      ].filter(Boolean),
     },
     plugins: [
       // NOTE: iModel.js specific plugin to allow exposing iModel.js shared libraries

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add options to disable ESLint, Babel (for node_modules) and Minification.

Linting causes considerable overhead (12+ seconds) on cold builds, and is often unnecessary, since most teams prefer lint as a separate npm script.

Also, when using our recommended browserlists, babel does not appear to make **any** significant changes to anything in node_modules, yet it takes a significant amount of time (20+ seconds).
