### PR TITLE
Update two webpack plugins. 3.4.12

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -63,7 +63,7 @@
     "jest-resolve": "24.9.0",
     "jest-watch-typeahead": "0.4.2",
     "mini-css-extract-plugin": "0.9.0",
-    "optimize-css-assets-webpack-plugin": "5.0.3",
+    "optimize-css-assets-webpack-plugin": "5.0.8",
     "pnp-webpack-plugin": "1.6.4",
     "postcss-flexbugs-fixes": "4.1.0",
     "postcss-loader": "3.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -62,7 +62,7 @@
     "jest-environment-jsdom-fourteen": "1.0.1",
     "jest-resolve": "24.9.0",
     "jest-watch-typeahead": "0.4.2",
-    "mini-css-extract-plugin": "0.9.0",
+    "mini-css-extract-plugin": "0.11.3",
     "optimize-css-assets-webpack-plugin": "5.0.8",
     "pnp-webpack-plugin": "1.6.4",
     "postcss-flexbugs-fixes": "4.1.0",


### PR DESCRIPTION
This will fix two vulnerabilities with the current version of react-scripts. The 4.x version should be good as these changes were already made there.

https://npmjs.com/advisories/1755

This will be the first PR merged into 3.x and released from there.