### PR TITLE
Bump react refresh

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
@@ -77,7 +77,7 @@
     "prompts": "2.4.0",
     "react-app-polyfill": "^2.0.0",
     "react-dev-utils": "^11.0.3",
-    "react-refresh": "^0.8.3",
+    "react-refresh": "^0.10.0",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
     "sass": "^1.32.8",


### PR DESCRIPTION
There seems to be an issue where even though the dep on react-refresh uses a ^, it still pulls in 0.8.3 and not the latest. On 0.8.3 you'll run into the following issue: https://github.com/imodeljs/imodeljs/discussions/2500



