### PR TITLE
Add support for magic comments in commonjs modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -474,7 +474,8 @@ module.exports = function (webpackEnv) {
       strictExportPresence: true,
       rules: [
         // Disable require.ensure as it's not a standard language feature.
-        { parser: { requireEnsure: false } },
+        // Add support for magic comments in commonjs modules (i.e. webpackIgnore for dynamic imports)
+        { parser: { requireEnsure: false,  commonjsMagicComments: true} },
         {
           // iModel.js Changes
           // always use source-map-loader and use strip-assert-loader on production builds;


### PR DESCRIPTION
Add support for magic comments in commonjs modules. This would be needed for ignoring dynamic remote imports (extensions)
