### PR TITLE
Allow IMJS_URL_PREFIX to be configured at runtime

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -136,6 +136,10 @@ module.exports = function (webpackEnv) {
 
   const shouldUseReactRefresh = env.raw.FAST_REFRESH;
 
+  if (env.raw.IMJS_URL_PREFIX === undefined) {
+    env.stringified["process.env"].IMJS_URL_PREFIX = `(globalThis.IMJS_URL_PREFIX ?? "")`;
+  }
+
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [


### PR DESCRIPTION
This should let applications set the value of `process.env.IMJS_URL_PREFIX` via a global `IMJS_URL_PREFIX` variable, ***if*** they did not have `IMJS_URL_PREFIX` set in their environment at build time.
