### PR TITLE
fix svg-sprite-loader rule.use to be an array

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -684,14 +684,16 @@ module.exports = function (webpackEnv) {
             {
               test: /\.svg$/,
               resourceQuery: /sprite/,
-              use: {
-                loader: require.resolve('svg-sprite-loader'),
-                options: {
-                  symbolId: '[name]-[hash:6]',
-                  runtimeCompat: true,
-                  spriteFilename: 'sprite-[hash:6].svg',
+              use: [
+                {
+                  loader: require.resolve('svg-sprite-loader'),
+                  options: {
+                    symbolId: '[name]-[hash:6]',
+                    runtimeCompat: true,
+                    spriteFilename: 'sprite-[hash:6].svg',
+                  },
                 },
-              },
+              ],
             },
             // "file" loader makes sure those assets get served by WebpackDevServer.
             // When you `import` an asset, you get its (virtual) filename.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "iTwin.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

According to Webpack v5 [documentation](https://webpack.js.org/configuration/module/#ruleuse) `Rule.use` should be an array and `svg-sprite-loader` rule had `use` as a regular object.
This was causing `craco` to fail for us.