### PR TITLE
add env DISABLE_COPY_ASSETS to provide a way to skip copying bentley package assets

### DIFF
--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -16,6 +16,7 @@ Current upstream is `react-scripts@5.0.1`, a diff of upstream and this fork can 
   | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use `source-map` instead of `cheap-module-source-map`. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
   | TRANSPILE_DEPS          | ✅ Used     | ✅ Used    | When set to `false`, webpack will not run babel on anything in node_modules. Transpiling dependencies can be costly, and is often not necessary when targeting newer browsers. |
   | DISABLE_TERSER          | 🚫 Ignored  | ✅ Used    | When set to `true`, skips all minification. Useful for PR builds and test apps. |
+  | DISABLE_COPY_ASSETS     | ✅ Used     | ✅ Used    | When set to `true`, skips applying the copy plugin to extract assets from @bentley or @itwinjs packages. |
 
 - Typing changes
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -53,6 +53,8 @@ const shouldTranspileDeps = process.env.TRANSPILE_DEPS !== 'false';
 
 const shouldMinify = process.env.DISABLE_TERSER !== 'true';
 
+const shouldCopyAssets = process.env.DISABLE_COPY_ASSETS !== 'true';
+
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -148,7 +150,7 @@ module.exports = function (webpackEnv) {
       },
     } : 'sass-loader';
 
-  const copyPluginPatterns = Object.keys(require(paths.appPackageJson).dependencies)
+  const copyPluginPatterns = shouldCopyAssets ? Object.keys(require(paths.appPackageJson).dependencies)
     .filter(dependency => dependency.startsWith('@bentley') || dependency.startsWith('@itwin'))
     .map(dependency => {
       return {
@@ -163,7 +165,7 @@ module.exports = function (webpackEnv) {
           return regex.exec(absoluteFilename)[2];
         },
       };
-    });
+    }) : undefined;
 
   // End iModel.js Changes block
 
@@ -745,7 +747,7 @@ module.exports = function (webpackEnv) {
       // NOTE: iModel.js specific plugin to copy a set of static resources from the node_modules
       // directory of each dependent package into the 'build/public' directory.
       // Used for resources such as locales, which are defined by each consuming package.
-      new CopyPlugin({ patterns: copyPluginPatterns }),
+      copyPluginPatterns && new CopyPlugin({ patterns: copyPluginPatterns }),
 
       // Inlines the webpack runtime script. This script is too small to warrant
       // a network request.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "iTwin.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
add env DISABLE_COPY_ASSETS to provide a way to skip copying bentley package assets
