### PR TITLE
Fix so copy assets can work when using npm.

### DIFF
--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -17,6 +17,7 @@ Current upstream is `react-scripts@5.0.1`, a diff of upstream and this fork can 
   | TRANSPILE_DEPS          | ✅ Used     | ✅ Used    | When set to `false`, webpack will not run babel on anything in node_modules. Transpiling dependencies can be costly, and is often not necessary when targeting newer browsers. |
   | DISABLE_TERSER          | 🚫 Ignored  | ✅ Used    | When set to `true`, skips all minification. Useful for PR builds and test apps. |
   | DISABLE_COPY_ASSETS     | ✅ Used     | ✅ Used    | When set to `true`, skips applying the copy plugin to extract assets from @bentley or @itwinjs packages. |
+  | USING_NPM               | ✅ Used     | ✅ Used    | When set to `true`, indicates that the application uses npm instead of pnpm. This disables a pnpm workaround while copying assets. (The pnpm workaround prevents assets copying from working in npm.) Ignored if `DISABLE_COPY_ASSETS` is `true`. |
 
 - Typing changes
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -55,6 +55,8 @@ const shouldMinify = process.env.DISABLE_TERSER !== 'true';
 
 const shouldCopyAssets = process.env.DISABLE_COPY_ASSETS !== 'true';
 
+const isUsingNpm = process.env.IS_USING_NPM === 'true';
+
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -157,7 +159,7 @@ module.exports = function (webpackEnv) {
         from: "**/public/**",
         noErrorOnMissing: true,
         context: path.dirname(require.resolve(`${paths.appNodeModules}/${dependency}/package.json`)),
-        globOptions: {
+        globOptions: isUsingNpm ? undefined : {
           ignore: ["**/node_modules/**"],
         },
         to({ absoluteFilename }) {

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -55,7 +55,7 @@ const shouldMinify = process.env.DISABLE_TERSER !== 'true';
 
 const shouldCopyAssets = process.env.DISABLE_COPY_ASSETS !== 'true';
 
-const isUsingNpm = process.env.IS_USING_NPM === 'true';
+const isUsingNpm = process.env.USING_NPM === 'true';
 
 // End iModel.js Changes block
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "iTwin.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Requires setting IS_USING_NPM environment variable to true.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
