### PR TITLE
fix ignore path problem

### DIFF
--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -10,14 +10,13 @@ Current upstream is `react-scripts@5.0.1`, a diff of upstream and this fork can 
 
   > Note: These configuration variables are an extension of the [Advanced Configurations](https://create-react-app.dev/docs/advanced-configuration) supported by create-react-app.
 
-  | Variable                | Development | Production | Usage                                                                                                                                                                                                |
-  | ----------------------- | ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the `fast-sass-loader` instead of `sass-loader`. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files.         |
-  | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use `source-map` instead of `cheap-module-source-map`. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
-  | TRANSPILE_DEPS          | ✅ Used     | ✅ Used    | When set to `false`, webpack will not run babel on anything in node_modules. Transpiling dependencies can be costly, and is often not necessary when targeting newer browsers. |
-  | DISABLE_TERSER          | 🚫 Ignored  | ✅ Used    | When set to `true`, skips all minification. Useful for PR builds and test apps. |
-  | DISABLE_COPY_ASSETS     | ✅ Used     | ✅ Used    | When set to `true`, skips applying the copy plugin to extract assets from @bentley or @itwinjs packages. |
-  | USING_NPM               | ✅ Used     | ✅ Used    | When set to `true`, indicates that the application uses npm instead of pnpm. This disables a pnpm workaround while copying assets. (The pnpm workaround prevents assets copying from working in npm.) Ignored if `DISABLE_COPY_ASSETS` is `true`. |
+  | Variable            | Development | Production | Usage                                                                                                                                                                                                |
+  | ------------------- | ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | USE_FAST_SASS       | ✅ Used     | ✅ Used    | When set to `true`, use the `fast-sass-loader` instead of `sass-loader`. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files.     |
+  | USE_FULL_SOURCEMAP  | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use `source-map` instead of `cheap-module-source-map`. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
+  | TRANSPILE_DEPS      | ✅ Used     | ✅ Used    | When set to `false`, webpack will not run babel on anything in node_modules. Transpiling dependencies can be costly, and is often not necessary when targeting newer browsers.                       |
+  | DISABLE_TERSER      | 🚫 Ignored  | ✅ Used    | When set to `true`, skips all minification. Useful for PR builds and test apps.                                                                                                                      |
+  | DISABLE_COPY_ASSETS | ✅ Used     | ✅ Used    | When set to `true`, skips applying the copy plugin to extract assets from @bentley or @itwinjs packages.                                                                                             |
 
 - Typing changes
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -55,8 +55,6 @@ const shouldMinify = process.env.DISABLE_TERSER !== 'true';
 
 const shouldCopyAssets = process.env.DISABLE_COPY_ASSETS !== 'true';
 
-const isUsingNpm = process.env.USING_NPM === 'true';
-
 // End iModel.js Changes block
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -159,8 +157,8 @@ module.exports = function (webpackEnv) {
         from: "**/public/**",
         noErrorOnMissing: true,
         context: path.dirname(require.resolve(`${paths.appNodeModules}/${dependency}/package.json`)),
-        globOptions: isUsingNpm ? undefined : {
-          ignore: ["/node_modules/**"],
+        globOptions: {
+          ignore: ["/node_modules/**", "**/index.html"],
         },
         to({ absoluteFilename }) {
           const regex = new RegExp("(public(?:\\\\|\/))(.*)");

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -160,7 +160,7 @@ module.exports = function (webpackEnv) {
         noErrorOnMissing: true,
         context: path.dirname(require.resolve(`${paths.appNodeModules}/${dependency}/package.json`)),
         globOptions: isUsingNpm ? undefined : {
-          ignore: ["**/node_modules/**"],
+          ignore: ["/node_modules/**"],
         },
         to({ absoluteFilename }) {
           const regex = new RegExp("(public(?:\\\\|\/))(.*)");

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "iTwin.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Other users have had the same issues with copy webpack plugin [here](https://github.com/webpack-contrib/copy-webpack-plugin/issues/689). There doesn't seem to be a consensus on what the solution is, and the issue is still open. I went into the files and am attaching the relevant code block [here](https://github.com/webpack-contrib/copy-webpack-plugin/blob/c51c09cdc18448be1ef743b37fe7f65f08bde177/src/index.js#L383-L399). It shows how globOptions is passed into [globby](https://github.com/sindresorhus/globby).
Looking at the code block, the plugin constructs a glob Path, and then passes that and the `globOptions` as is into `globby`. globby then uses `fast-glob` to add the `globOptions.ignore` strings. Over the course of last month, `globby` and `fast-glob` both had one PR merged addressing `ignore`. 

`globby` merged a [PR](https://github.com/sindresorhus/globby/pull/252) that addressed its default handling of `ignore` options.
`fast-glob` merged a [PR](https://github.com/mrmlnc/fast-glob/pull/406) that addressed misuse of the `ignore` options.

I started by setting `noErrorOnMissing` to `false` and ran `pnpm start` with `USING_NPM` set to true. I found 18 errors were raised, all with the same message as this:
```
ERROR in unable to locate '/Users/{USER_NAME}/Documents/your-app-name/node_modules/.pnpm/@itwin+core-bentley@4.0.6/node_modules/@itwin/core-bentley/**/public/**' glob
```
When `USING_NPM` is set to false, the same errors were raised, but 29 this time.
This means our default `working` solution raises errors that aren't raised because we set `noErrorOnMissing` to `true`. 
The change I made involved just tweaking the `ignore` glob we pass in such that the compilation errors went back to 18 errors.

The fix as is will be fine, it will revert the behavior of copy webpack plugin back to what it was. Another solution would be to figure out how to fix the glob pattern that we pass into `from`. The lines [here](https://github.com/webpack-contrib/copy-webpack-plugin/blob/c51c09cdc18448be1ef743b37fe7f65f08bde177/src/index.js#L366-L369) in the plugin notes how the full glob path is formed (by joining the `context` with the `form` glob pattern we pass in). 

One last thing to note is copy-webpack-plugin actually hasn't bumped their versions of `globby` or `fast-glob` for [almost a year....](https://github.com/webpack-contrib/copy-webpack-plugin/blame/c51c09cdc18448be1ef743b37fe7f65f08bde177/package.json#L52-L54)
