### PR TITLE
fix webpack config interpreting cjs files as assets

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -707,7 +707,9 @@ module.exports = function (webpackEnv) {
               // its runtime that would otherwise be processed through "file" loader.
               // Also exclude `html` and `json` extensions so they get processed
               // by webpacks internal loaders.
-              exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+              
+              // note: 10/16/23 update to also exclude cjs files as packages such as axios may be configured to prefer these for the browser
+              exclude: [/^$/, /\.(js|mjs|jsx|cjs|ts|tsx)$/, /\.html$/, /\.json$/],
               type: 'asset/resource',
             },
             // ** STOP ** Are you adding a new loader?

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "iTwin.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- the current `webpack.config.js` would interpret `.cjs` files as assets preventing them from being loaded as source
- solution was to amend the rule for `asset/resource` to exclude `.cjs` files
- this issue came up because in the newer `axios` versions are configured to pull the source as `.cjs` for requires from a browser
- see [🚑 webpack - loading cjs as an asset instead of source ](https://github.com/facebook/create-react-app/pull/12021#issuecomment-1108426483)